### PR TITLE
Yongyang dev

### DIFF
--- a/backend2/main.py
+++ b/backend2/main.py
@@ -1,9 +1,9 @@
 import asyncio
 import traceback
-from typing import List
+from typing import List, Optional
 from collections import deque
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Path, Query
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
@@ -93,3 +93,37 @@ async def get_request_history():
     The history is limited to the last MAX_REQUEST_HISTORY_SIZE requests.
     """
     return list(request_history_cache)
+
+
+@app.get("/api/requests/history/{index}", response_model=TaskSpecs)
+async def get_request_history_by_index(
+    index: int = Path(..., title="Index of the request in cache", ge=0)
+):
+    current_cache_size = len(request_history_cache)
+    if index >= current_cache_size:
+        raise HTTPException(status_code=404, detail=f"Index {index} out of bounds. Cache currently has {current_cache_size} items.")
+    try:
+        if index < 0:
+             raise HTTPException(status_code=400, detail="Index must be a non-negative integer.")
+        return request_history_cache[index]
+    except IndexError:
+        raise HTTPException(status_code=404, detail=f"Request at index {index} not found.")
+
+
+@app.get("/api/requests/history/range/", response_model=List[TaskSpecs])
+async def get_request_history_by_range(
+    left_pos: int = Query(..., title="Start index of the range (inclusive)", ge=0),
+    right_pos: int = Query(..., title="End index of the range (inclusive)", ge=0)
+):
+    if left_pos > right_pos:
+        return []
+
+    current_cache_size = len(request_history_cache)
+    
+    actual_left = max(0, left_pos)
+    actual_right = min(current_cache_size, right_pos + 1)
+
+    if actual_left >= actual_right:
+        return []
+
+    return list(request_history_cache)[actual_left:actual_right]


### PR DESCRIPTION
Changes Implemented:

In-Memory Cache (request_history_cache):

A global collections.deque named request_history_cache has been initialized in backend2/main.py.
The cache is configured with a maxlen of MAX_REQUEST_HISTORY_SIZE (currently set to 100) to store the most recent N requests. It will automatically discard the oldest requests when the cache is full.

Request Storage:

Incoming TaskSpecs objects are now appended to request_history_cache in both:
The HTTP POST endpoint: handle_complete_task.
The WebSocket endpoint: handle_complete_task_websocket.

Cache Access Endpoints:

GET /api/requests/history:
Returns a list of all TaskSpecs objects currently in the request_history_cache.
GET /api/requests/history/{index} :
Allows retrieval of a specific TaskSpecs object from the cache by its 0-based index.
GET /api/requests/history/range/ :
Allows retrieval of a list of TaskSpecs objects from the cache within a specified inclusive index range (left_pos to right_pos).
